### PR TITLE
feat: REST API for fetching transactions per payment reference

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -2,7 +2,7 @@ const express = require('express')
 const cors = require('cors')
 const cron = require('node-cron')
 require('dotenv').config()
-const getTransactionsFromNearIndexerDatabase = require('./model/near_indexer_repository')
+const {getTransactionsFromNearIndexerDatabase, getTransactionsFromPaymentReference} = require('./model/near_indexer_repository')
 const getServerConfig = require('../src/near-utility-server.config')
 const serverConfig = getServerConfig(process.env.NODE_ENV || 'development')
 
@@ -32,6 +32,15 @@ app.use(express.json())
 app.get('/', (req, res) => {
     res.send('Hello World!')
 })
+
+app.get('/payments/:paymentAddress/:paymentReference', async (req, res) => {
+    try {
+        const data = await getTransactionsFromPaymentReference(req.params.paymentAddress, req.params.paymentReference);
+        res.json({ success: true, data });
+    } catch(e) {
+        return res.status(500).send({ success: false, error: e.message})
+    }
+});
 
 app.get('/transactions-from-indexer', async (req, res) => {
     try {

--- a/server/model/near_indexer_repository.js
+++ b/server/model/near_indexer_repository.js
@@ -53,4 +53,47 @@ LIMIT $3`
     }
 }
 
-module.exports = getTransactionsFromNearIndexerDatabase
+async function getTransactionsFromPaymentReferenceAndAddress(address, paymentReference) {
+    const query = `SELECT t.transaction_hash as "txHash",
+        b.block_height as block,
+        t.block_timestamp as "blockTimestamp",
+        t.signer_account_id as payer,
+        r.receiver_account_id as payee,
+        COALESCE(a.args::json->>'deposit', '') as deposit,
+        COALESCE(a.args::json->>'method_name', '') as method_name,
+        COALESCE((a.args::json->'args_json')::json->>'to', '') as "to",
+        COALESCE((a.args::json->'args_json')::json->>'amount', '') as amount,
+        (a.args::json->'args_json')::json->>'payment_reference' as paymentReference,
+        (select MAX(block_height) from blocks) - b.block_height as confirmations
+        FROM transactions t
+        INNER JOIN transaction_actions a ON (a.transaction_hash = t.transaction_hash)
+        INNER JOIN receipts r ON (r.originated_from_transaction_hash = t.transaction_hash)
+        INNER JOIN blocks b ON (b.block_timestamp = r.included_in_block_timestamp)
+        INNER JOIN execution_outcomes e ON (e.receipt_id = r.receipt_id)
+        INNER JOIN action_receipt_actions ra ON (ra.receipt_id = r.receipt_id)
+        WHERE t.receiver_account_id = $2
+        AND r.predecessor_account_id != 'system'
+        AND a.action_kind = 'FUNCTION_CALL'
+        AND e.status = 'SUCCESS_VALUE'
+        AND t.receiver_account_id = $1
+        AND b.block_height >= (select MAX(block_height) from blocks) - 1e8
+        AND (a.args::json->'args_json')::json->>'payment_reference' = $3
+        AND ra.action_kind = 'TRANSFER'
+        ORDER BY b.block_height DESC
+        LIMIT 100`;
+
+    try {
+        const client = new Client({
+        connectionString: this.connectionString,
+        });
+        await client.connect();
+        const res = await client.query(query, [nearConfig.contractName, address, `0x${paymentReference}`]);
+        await client.end();
+        return res.rows;
+    } catch (err) {
+        console.log(err.stack);
+        throw Error(`Error retrieving data: ${err.message}\n${err.stack}`);
+    }
+}
+
+module.exports = {getTransactionsFromNearIndexerDatabase, getTransactionsFromPaymentReference}


### PR DESCRIPTION
### Motivation

This change would completely abstract the SQL layer for Request `payment-detection` library and open the possibility to detect NEAR payments from a front-end / dapp.